### PR TITLE
docs: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,60 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]:"
+labels: ''
+assignees: ''
+
+---
+
+**For reporting bugs and problems with content, include:**
+
+- A description of the problem
+- A link to the page that has the problem (if it's on a specific page)
+- An explanation as to why this is a problem. Ideally, explain _who_ is affected by this. "It was confusing for me" _is_ a valid answer to this!
+- A suggestion of a fix, if you have one in mind!
+- Please ensure the new content respects the [Schrödinger Hat Code of Conduct](https://www.schrodinger-hat.it/code-of-conduct)
+
+--- 
+
+If this is your first issue that you open, please read this [open source contribution guide](https://opensource.guide/how-to-contribute/#opening-an-issue).
+
+> Note: Feel free to remove any section according to your needs.
+
+**Describe the issue**
+
+- Provide a clear and concise description of the challenge you are running into.
+
+**Your example website or app** (if possible)
+
+Which website or app were you using when the bug happened?
+
+Note:
+- Your bug will may get fixed much faster if we can run your code and it doesn't have extra dependencies besides the one from the original project.
+- To create a shareable code example you can use Stackblitz (https://stackblitz.com/). Please no localhost URLs.
+- Please read these tips for providing a minimal example: https://stackoverflow.com/help/mcve.
+
+
+**Steps to reproduce the bug or issue** (if possible)
+
+- Describes the steps we have to take to reproduce the behavior.
+
+**Expected behavior**
+
+- Provide a clear and concise description of what you expected to happen
+
+**Screenshots and videos**
+
+- If applicable, add screenshots or a video to help explain your problem.
+For more information on the supported file image/file types and the file size limits, please refer
+to the following [link](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/attaching-files)
+
+**Platform**
+
+- OS: [e.g. macOS, Windows, Linux]
+- Browser: [e.g. Chrome, Safari, Firefox]
+- Version: [e.g. 91.1]
+
+**Additional context**
+
+- Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]:"
+labels: ''
+assignees: ''
+
+---
+
+**For suggesting new content**:
+- If you're suggesting an addition to an existing page, explain what is missing and why this is a problem.
+- Please ensure the new content respects the [Schrödinger Hat Code of Conduct](https://www.schrodinger-hat.it/code-of-conduct)
+
+--- 
+
+If this is your first issue that you open, please read this [open source contribution guide](https://opensource.guide/how-to-contribute/#opening-an-issue).
+
+## Template for new content
+> Note: Feel free to remove any section according to your needs.
+
+**Describe the new content**
+
+Please include a description of the new content:
+- What is missing?
+- Where is it missing?
+- Why is it needed?
+
+**Your example on how the new content would be like**
+
+- If possible, please provide visual aid, (safe) external links, etc., that would help to understand the proposed new content better.
+
+**Additional content**
+
+- If needed, include anything else that would help to solidify the new proposed changes.


### PR DESCRIPTION
Issue templates for Bug reports and Feature requests have been created. This will help to accelerate the process of creating and opening an issue for the Schrödinger Hat website.